### PR TITLE
feat(posts): add getSuePosts function to get all posts

### DIFF
--- a/lib/getSuePosts.ts
+++ b/lib/getSuePosts.ts
@@ -1,4 +1,26 @@
-export async function getSuePosts() {
-    console.log("getSuePosts called");
-    return [];
+import { supabase } from './supabaseClient';
+
+// Defines the TypeScript interface for a SuePost returned from Supabase
+export interface SuePostResponse {
+    id: number;
+    created_at: string;
+    photo_url: string;
+    location: string;
+    caption: string;
+    secret_used: string;
+}
+
+// Retrieves all Sue posts, ordered by creation data (newest first)
+export async function getSuePosts(): Promise<SuePostResponse[]> {
+    const { data, error } = await supabase
+    .from('posts')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+    if (error) {
+        console.error(error);
+        throw error;
+    }
+
+    return data as SuePostResponse[];
 }

--- a/lib/getSuePosts.ts
+++ b/lib/getSuePosts.ts
@@ -4,10 +4,10 @@ import { supabase } from './supabaseClient';
 export interface SuePostResponse {
     id: number;
     created_at: string;
-    photo_url: string;
-    location: string;
-    caption: string;
-    secret_used: string;
+    photo_url: string | null;
+    location: string | null;
+    caption: string | null;
+    secret_used: string | null;
 }
 
 // Retrieves all Sue posts, ordered by creation data (newest first)


### PR DESCRIPTION
### Summary

Adds the `getSuePosts` helper function to retrieve all Sue's travel posts from Supabase for gallery display. This function fetches all rows from the `posts` table and orders them by `created_at` descending so the newest posts appear first.

### Changes

- Adds `app/lib/getSuePosts.ts`:
  - Defines `SuePostResponse` interface matching Supabase `posts` table structure.
  - Defines `getSuePosts` async function to fetch all posts in descending order of creation.

### Next Steps

- Create a test component or temporary console log to confirm retrieval is working.
- Integrate this function with the gallery component to display Sue's travel posts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved post retrieval to display the latest posts with details such as photo, location, caption, and more.
* **Bug Fixes**
  * Enhanced error handling to ensure more reliable loading of posts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->