### PR TITLE
feat(upload): create initial ui for posting a photo

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,11 @@
 "use client";
-import { Button } from "@/components/retroui/Button";
+import UploadForm from "@/components/UploadForm";
 
 export default function Home() {
   return (
     <main>
       <h1>{"Sue's World Tour"}</h1>
-      <p>{"Welcome to Sue's World Tour!"}</p>
-      <Button>Retro UI works!</Button>
+      <UploadForm></UploadForm>
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   return (
     <main>
       <h1>{"Sue's World Tour"}</h1>
-      <UploadForm></UploadForm>
+      <UploadForm />
     </main>
   );
 }

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -10,7 +10,7 @@ export default function UploadForm() {
                     <InputStyleWithLabel label="Image Upload" type="file" id="file" placeholder=""/>
                     <InputStyleWithLabel label="Caption" type="text" id="caption" placeholder="Say whatever you want!"/>
                     <InputStyleWithLabel label="Location" type="text" id="location" placeholder="Where is she now?"/>
-                    <InputStyleWithLabel label="Password" type="text" id="password" placeholder="Enter Sue's password"/>
+                    <InputStyleWithLabel label="Password" type="password" id="password" placeholder="Enter Sue's password"/>
                     <Button className="m-2">Post!</Button>
                 </Card.Content>
             </Card>

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -1,7 +1,19 @@
+import { Card } from "@/components/retroui/Card";
+import { Button } from "@/components/retroui/Button";
+import InputStyleWithLabel from "./retroui/InputWithLabel";
+
 export default function UploadForm() {
     return (
         <div>
-            <p>UploadForm component placeholder.</p>
+            <Card className="w-[277px] h-[410px] shadow-none hover:shadow-none flex flex-col">
+                <Card.Content className="flex flex-col justify-center items-center">
+                    <InputStyleWithLabel label="Image Upload" type="file" id="file" placeholder=""/>
+                    <InputStyleWithLabel label="Caption" type="text" id="caption" placeholder="Say whatever you want!"/>
+                    <InputStyleWithLabel label="Location" type="text" id="location" placeholder="Where is she now?"/>
+                    <InputStyleWithLabel label="Password" type="text" id="password" placeholder="Enter Sue's password"/>
+                    <Button className="m-2">Post!</Button>
+                </Card.Content>
+            </Card>
         </div>
     );
 }

--- a/components/retroui/Card.tsx
+++ b/components/retroui/Card.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/utils";
+import { HTMLAttributes } from "react";
+import { Text } from "./Text";
+ 
+interface ICardProps extends HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+ 
+const Card = ({ className, ...props }: ICardProps) => {
+  return (
+    <div
+      className={cn(
+        "inline-block border-2 shadow-md transition-all hover:shadow-xs bg-card",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+ 
+const CardHeader = ({ className, ...props }: ICardProps) => {
+  return (
+    <div
+      className={cn("flex flex-col justify-start p-4", className)}
+      {...props}
+    />
+  );
+};
+ 
+const CardTitle = ({ className, ...props }: ICardProps) => {
+  return <Text as="h3" className={cn("mb-2", className)} {...props} />;
+};
+ 
+const CardDescription = ({ className, ...props }: ICardProps) => (
+  <p className={cn("text-muted-foreground", className)} {...props} />
+);
+ 
+const CardContent = ({ className, ...props }: ICardProps) => {
+  return <div className={cn("p-4", className)} {...props} />;
+};
+ 
+const CardComponent = Object.assign(Card, {
+  Header: CardHeader,
+  Title: CardTitle,
+  Description: CardDescription,
+  Content: CardContent,
+});
+ 
+export { CardComponent as Card };

--- a/components/retroui/Input.tsx
+++ b/components/retroui/Input.tsx
@@ -1,0 +1,25 @@
+import React, { InputHTMLAttributes } from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+}
+
+export const Input: React.FC<InputProps> = ({
+  type = "text",
+  placeholder = "Enter text",
+  className = "",
+  ...props
+}) => {
+  return (
+    <input
+      type={type}
+      placeholder={placeholder}
+      className={`px-4 py-2 w-full border-2 shadow-md transition focus:outline-hidden focus:shadow-xs ${
+        props["aria-invalid"]
+          ? "border-red-500 text-red-500 shadow-xs shadow-red-600"
+          : ""
+      } ${className}`}
+      {...props}
+    />
+  );
+};

--- a/components/retroui/InputWithLabel.tsx
+++ b/components/retroui/InputWithLabel.tsx
@@ -1,0 +1,18 @@
+import { Input } from "@/components/retroui/Input";
+import { Label } from "@/components/retroui/Label";
+
+interface InputWithLabelProps {
+  label: string;
+  type: string;
+  id: string;
+  placeholder: string;
+}
+
+export default function InputStyleWithLabel(props: InputWithLabelProps) {
+  return (
+    <div className="w-full grid gap-1.5 p-2">
+      <Label htmlFor="file">{props.label}</Label>
+      <Input type={props.type} id={props.id} placeholder={props.placeholder} />
+    </div>
+  );
+}

--- a/components/retroui/InputWithLabel.tsx
+++ b/components/retroui/InputWithLabel.tsx
@@ -11,7 +11,7 @@ interface InputWithLabelProps {
 export default function InputStyleWithLabel(props: InputWithLabelProps) {
   return (
     <div className="w-full grid gap-1.5 p-2">
-      <Label htmlFor="file">{props.label}</Label>
+      <Label htmlFor={props.id}>{props.label}</Label>
       <Input type={props.type} id={props.id} placeholder={props.placeholder} />
     </div>
   );

--- a/components/retroui/InputWithLabel.tsx
+++ b/components/retroui/InputWithLabel.tsx
@@ -12,7 +12,12 @@ export default function InputStyleWithLabel(props: InputWithLabelProps) {
   return (
     <div className="w-full grid gap-1.5 p-2">
       <Label htmlFor={props.id}>{props.label}</Label>
-      <Input type={props.type} id={props.id} placeholder={props.placeholder} />
+      <Input 
+        type={props.type} 
+        id={props.id} 
+        placeholder={props.placeholder}
+        className={props.type === "file" ? "cursor-pointer" : ""}
+      />
     </div>
   );
 }

--- a/components/retroui/Label.tsx
+++ b/components/retroui/Label.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+export const Label = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) => (
+  <LabelPrimitive.Root className={cn(labelVariants(), className)} {...props} />
+);

--- a/components/retroui/Text.tsx
+++ b/components/retroui/Text.tsx
@@ -1,0 +1,37 @@
+import type { ElementType, HTMLAttributes } from "react";
+import { type VariantProps, cva } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const textVariants = cva("font-head", {
+  variants: {
+    as: {
+      p: "font-sans text-base",
+      li: "font-sans text-base",
+      a: "font-sans text-base hover:underline underline-offset-2 decoration-primary",
+      h1: "text-4xl lg:text-5xl font-bold",
+      h2: "text-3xl lg:text-4xl font-semibold",
+      h3: "text-2xl font-medium",
+      h4: "text-xl font-normal",
+      h5: "text-lg font-normal",
+      h6: "text-base font-normal",
+    },
+  },
+  defaultVariants: {
+    as: "p",
+  },
+});
+
+interface TextProps
+  extends Omit<HTMLAttributes<HTMLElement>, "className">,
+    VariantProps<typeof textVariants> {
+  className?: string;
+}
+
+export const Text = (props: TextProps) => {
+  const { className, as, ...otherProps } = props;
+  const Tag: ElementType = as || "p";
+
+  return (
+    <Tag className={cn(textVariants({ as }), className)} {...otherProps} />
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sues-world-tour",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.7",
         "@supabase/supabase-js": "^2.50.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -963,6 +964,85 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1394,7 +1474,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1404,7 +1484,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2508,7 +2588,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
     "@supabase/supabase-js": "^2.50.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,15 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
-
-@theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-
-  /* Retro UI shadows */
+@theme {
+  --font-head: var(--font-head);
+  --font-sans: var(--font-sans);
+ 
   --shadow-xs: 1px 1px 0 0 var(--border);
   --shadow-sm: 2px 2px 0 0 var(--border);
   --shadow: 3px 3px 0 0 var(--border);
@@ -17,114 +12,59 @@
   --shadow-lg: 6px 6px 0 0 var(--border);
   --shadow-xl: 10px 10px 0 1px var(--border);
   --shadow-2xl: 16px 16px 0 1px var(--border);
-
+ 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
+  --color-primary-hover: var(--primary-hover);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
-
+ 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.902 0.166 98.8);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: #fff;
+  --foreground: #000;
+  --card: #fff;
+  --card-foreground: #000;
+  --primary: #ffdb33;
+  --primary-hover: #ffcc00;
+  --primary-foreground: #000;
+  --secondary: #000;
+  --secondary-foreground: #fff;
+  --muted: #aeaeae;
+  --muted-foreground: #5a5a5a;
+  --accent: #fae583;
+  --accent-foreground: #000;
+  --destructive: #e63946;
+  --destructive-foreground: #fff;
+  --border: #000;
 }
-
+ 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
+  --background: #1a1a1a;
+  --foreground: #f5f5f5;
+  --card: #242424;
+  --card-foreground: #f5f5f5;
+  --primary: #ffdb33;
+  --primary-hover: #ffcc00;
+  --primary-foreground: #000;
+  --secondary: #3a3a3a;
+  --secondary-foreground: #f5f5f5;
+  --muted: #3f3f46;
+  --muted-foreground: #a0a0a0;
+  --accent: #fae583;
+  --accent-foreground: #000;
+  --destructive: #e63946;
+  --destructive-foreground: #fff;
+  --border: #3a3a3a;
 }


### PR DESCRIPTION
## Summary

Adds the initial UI for the `UploadForm` component, allowing users to prepare for posting a photo to Sue's World Tour gallery. This is UI only; functionality for uploading and posting metadata will be added in a future PR.

## Changes

- Creates `UploadForm` component matching polaroid styling for consistency in the gallery
- Includes labeled file input using Retro UI components

## Next Steps

- Connect the upload functionality to Supabase storage
- Add form validation and metadata insertion on submit
- Integrate with the gallery for immediate preview after upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an image upload form with fields for caption, location, and password, wrapped in a visually styled card interface.
  * Added new reusable UI components for cards, labels, inputs, and typography to improve form and layout consistency.

* **Style**
  * Simplified and updated the application's color theme for both light and dark modes using straightforward hex color codes.

* **Chores**
  * Added a new dependency to support accessible label components in forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->