### PR TITLE
refactor(upload-nav): restyle the upload form and add basic nav

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,8 +1,12 @@
+import UploadLinkPolaroid from "@/components/UploadLinkPolaroid";
+
 export default function GalleryPage() {
     return (
         <main>
-            <h1>Gallery Page</h1>
-            <p>{"This is the gallery page for Sue's World Tour."}</p>
+            <h1 className="flex justify-center text-7xl">Gallery Page</h1>
+            <div className="h-screen flex justify-center items-center">
+                <UploadLinkPolaroid />
+            </div>
         </main>
     );
 } 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
   return (
     <main>
       <h1 className="flex justify-center text-7xl">{"Sue's World Tour"}</h1>
-      <div className="h-screen flex justify-center items-center">
+      <div className="min-h-[100vh] flex justify-center items-center">
         <Link href="/gallery">
           <Button>Get Started</Button>
         </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,16 @@
 "use client";
-import UploadForm from "@/components/UploadForm";
+import Link from "next/link";
+import { Button } from "@/components/retroui/Button";
 
 export default function Home() {
   return (
     <main>
-      <h1>{"Sue's World Tour"}</h1>
-      <UploadForm />
+      <h1 className="flex justify-center text-7xl">{"Sue's World Tour"}</h1>
+      <div className="h-screen flex justify-center items-center">
+        <Link href="/gallery">
+          <Button>Get Started</Button>
+        </Link>
+      </div>
     </main>
   );
 }

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,8 +1,11 @@
+import UploadForm from "@/components/UploadForm";
+
 export default function UploadPage() {
     return (
         <main>
-            <h1>Upload Page</h1>
-            <p>{"This is the upload page for Sue's World Tour."}</p>
+            <div className="h-screen flex justify-center items-center">
+                <UploadForm />
+            </div>
         </main>
     );
 } 

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -4,16 +4,17 @@ import InputStyleWithLabel from "./retroui/InputWithLabel";
 
 export default function UploadForm() {
     return (
-        <div>
-            <Card className="w-[277px] h-[410px] shadow-none hover:shadow-none flex flex-col">
-                <Card.Content className="flex flex-col justify-center items-center">
-                    <InputStyleWithLabel label="Image Upload" type="file" id="file" placeholder=""/>
-                    <InputStyleWithLabel label="Caption" type="text" id="caption" placeholder="Say whatever you want!"/>
-                    <InputStyleWithLabel label="Location" type="text" id="location" placeholder="Where is she now?"/>
-                    <InputStyleWithLabel label="Password" type="password" id="password" placeholder="Enter Sue's password"/>
-                    <Button className="m-2">Post!</Button>
-                </Card.Content>
-            </Card>
-        </div>
+        <Card className="w-[350px] shadow-none hover:shadow-none">
+            <Card.Content>
+                <div className="w-full aspect-square border-dashed border-2"></div>
+            </Card.Content>
+            <Card.Content className="flex-col justify-content items-center">
+                <InputStyleWithLabel label="Upload Photo" type="file" id="file" placeholder="" />
+                <InputStyleWithLabel label="Caption" type="text" id="caption" placeholder="Write whatever you want" />
+                <InputStyleWithLabel label="Location" type="text" id="location" placeholder="Where is she now?" />
+                <InputStyleWithLabel label="Password" type="password" id="password" placeholder="What's the password?" />
+                <Button className="m-1">Upload</Button>
+            </Card.Content>
+        </Card>
     );
 }

--- a/components/UploadLinkPolaroid.tsx
+++ b/components/UploadLinkPolaroid.tsx
@@ -8,7 +8,7 @@ export default function UploadLinkPolaroid() {
             <Card.Content>
                 <div className="w-full aspect-square border-dashed border-2"></div>
             </Card.Content>
-            <Card.Content className="flex-col justify-content items-center">
+            <Card.Content className="flex-col justify-center items-center">
                 <Link href="/upload" aria-label="Navigate to upload page">
                     <Button className="m-1">Add a photo</Button>
                 </Link>

--- a/components/UploadLinkPolaroid.tsx
+++ b/components/UploadLinkPolaroid.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function UploadLinkPolaroid() {
     return (
-        <Card className="w-[300px] shadow-none hover:shadow-none">
+        <Card className="w-full max-w-[300px] shadow-none hover:shadow-none">
             <Card.Content>
                 <div className="w-full aspect-square border-dashed border-2"></div>
             </Card.Content>

--- a/components/UploadLinkPolaroid.tsx
+++ b/components/UploadLinkPolaroid.tsx
@@ -1,0 +1,18 @@
+import { Card } from "@/components/retroui/Card";
+import { Button } from "@/components/retroui/Button"
+import Link from "next/link";
+
+export default function UploadLinkPolaroid() {
+    return (
+        <Card className="w-[300px] shadow-none hover:shadow-none">
+            <Card.Content>
+                <div className="w-full aspect-square border-dashed border-2"></div>
+            </Card.Content>
+            <Card.Content className="flex-col justify-content items-center">
+                <Link href="/upload">
+                <Button className="m-1">Add a photo</Button>
+                </Link>
+            </Card.Content>
+        </Card>
+    );
+}

--- a/components/UploadLinkPolaroid.tsx
+++ b/components/UploadLinkPolaroid.tsx
@@ -9,8 +9,8 @@ export default function UploadLinkPolaroid() {
                 <div className="w-full aspect-square border-dashed border-2"></div>
             </Card.Content>
             <Card.Content className="flex-col justify-content items-center">
-                <Link href="/upload">
-                <Button className="m-1">Add a photo</Button>
+                <Link href="/upload" aria-label="Navigate to upload page">
+                    <Button className="m-1">Add a photo</Button>
                 </Link>
             </Card.Content>
         </Card>

--- a/components/retroui/InputWithLabel.tsx
+++ b/components/retroui/InputWithLabel.tsx
@@ -10,7 +10,7 @@ interface InputWithLabelProps {
 
 export default function InputStyleWithLabel(props: InputWithLabelProps) {
   return (
-    <div className="w-full grid gap-1.5 p-2">
+    <div className="grid gap-1.5 p-2">
       <Label htmlFor={props.id}>{props.label}</Label>
       <Input 
         type={props.type} 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -36,7 +36,7 @@
   --foreground: #000;
   --card: #fff;
   --card-foreground: #000;
-  --primary: #ffdb33;
+  --primary: #e23123;
   --primary-hover: #ffcc00;
   --primary-foreground: #000;
   --secondary: #000;


### PR DESCRIPTION
## Summary

Refactors the existing `UploadForm` UI and introduces basic navigation between key pages in Sue's World Tour. This is a layout-focused PR to unify the visual design of the upload experience and enable user flow between landing, gallery, and upload.

## Changes

- Restyled `UploadForm` to match polaroid-style layout used in the gallery
- Adjusted component sizing and spacing for consistent alignment
- Added labeled inputs using Retro UI components
- Introduced navigation links between `landing`, `gallery`, and `upload` pages using Next.js `Link`

## Next Steps

- Hook up Supabase upload logic to the form
- Add error handling and validation states to the input fields
- Route user back to the gallery with preview after a successful upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Add a photo" card on the gallery page for easy navigation to the upload page.

* **Enhancements**
  * Improved layout and styling across the homepage, gallery, and upload pages for better centering and visual appeal.
  * Updated the upload form with a clearer placeholder, revised labels, and refined button text.
  * Changed the primary theme color from yellow to red for a refreshed look.

* **Style**
  * Adjusted spacing and alignment in form components for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->