### PR TITLE
feat(sue-polaroid): build basic polaroid and gallery structure

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,13 +1,26 @@
 import UploadLinkPolaroid from "@/components/UploadLinkPolaroid";
 import SuePolaroid from "@/components/SuePolaroid";
+import { getSuePosts } from "@/lib/getSuePosts";
 
-export default function GalleryPage() {
+export default async function GalleryPage() {
+    const posts = await getSuePosts();
+
+    const suePolaroids = posts.map((post) => (
+        <SuePolaroid
+            key={post.id}
+            photoUrl={post.photo_url}
+            caption={post.caption}
+            location={post.location}
+            createdAt={post.created_at}
+        />
+    ));
+
     return (
         <main>
             <h1 className="flex justify-center text-7xl">Gallery Page</h1>
             <div className="h-screen flex justify-center items-center">
                 <UploadLinkPolaroid />
-                <SuePolaroid />
+                {suePolaroids}
             </div>
         </main>
     );

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,4 +1,5 @@
 import UploadLinkPolaroid from "@/components/UploadLinkPolaroid";
+import SuePolaroid from "@/components/SuePolaroid";
 
 export default function GalleryPage() {
     return (
@@ -6,6 +7,7 @@ export default function GalleryPage() {
             <h1 className="flex justify-center text-7xl">Gallery Page</h1>
             <div className="h-screen flex justify-center items-center">
                 <UploadLinkPolaroid />
+                <SuePolaroid />
             </div>
         </main>
     );

--- a/components/SuePolaroid.tsx
+++ b/components/SuePolaroid.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@/components/retroui/Card";
+import { Text } from "@/components/retroui/Text";
 
 interface SuePolaroidProps {
     photoUrl: string;
@@ -10,16 +11,16 @@ interface SuePolaroidProps {
 export default function SuePolaroid(props: SuePolaroidProps) {
     return (
         <div>
-            <Card className="w-full max-w-[275px] min-w-[275px] min-h-[355px] shadow-none hover:shadow-none">
+            <Card className="w-full max-w-[275px] min-w-[275px] min-h-[355px] max-h-[355px] shadow-none hover:shadow-none">
                 <Card.Content>
-                    <div className="w-full aspect-square border border-2">
-                        <img src={props.photoUrl} alt={`Sue's photo at ${props.location}`} />
+                    <div className="w-full aspect-square border-2">
+                        <img src={props.photoUrl} alt={`Sue's photo at ${props.location}`} className="w-full h-full object-cover" />
                     </div>
                 </Card.Content>
                 <Card.Content className="flex-col justify-center items-center">
-                    <p className="text-sm text-gray-500">{props.caption}</p>
-                    <p className="text-sm text-gray-500">{props.location}</p>
-                    <p className="text-sm text-gray-500">{props.createdAt}</p>
+                    <Text as="p" className="text-md">{props.caption}</Text>
+                    <Text as="p" className="text-md">{props.location}</Text>
+                    <Text as="p" className="text-md">{props.createdAt.split("T")[0]}</Text>
                 </Card.Content>
             </Card>
         </div>

--- a/components/SuePolaroid.tsx
+++ b/components/SuePolaroid.tsx
@@ -1,7 +1,27 @@
-export default function SuePolaroid() {
+import { Card } from "@/components/retroui/Card";
+
+interface SuePolaroidProps {
+    photoUrl: string;
+    caption: string;
+    location: string;
+    createdAt: string;
+}
+
+export default function SuePolaroid(props: SuePolaroidProps) {
     return (
         <div>
-            <p>SuePolaroid component placeholder.</p>
+            <Card className="w-full max-w-[275px] min-w-[275px] min-h-[355px] shadow-none hover:shadow-none">
+                <Card.Content>
+                    <div className="w-full aspect-square border border-2">
+                        <img src={props.photoUrl} alt={`Sue's photo at ${props.location}`} />
+                    </div>
+                </Card.Content>
+                <Card.Content className="flex-col justify-center items-center">
+                    <p className="text-sm text-gray-500">{props.caption}</p>
+                    <p className="text-sm text-gray-500">{props.location}</p>
+                    <p className="text-sm text-gray-500">{props.createdAt}</p>
+                </Card.Content>
+            </Card>
         </div>
     );
 }

--- a/components/UploadLinkPolaroid.tsx
+++ b/components/UploadLinkPolaroid.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function UploadLinkPolaroid() {
     return (
-        <Card className="w-full max-w-[275px] shadow-none hover:shadow-none">
+        <Card className="w-full max-w-[275px] min-w-[275px] min-h-[355px] max-h-[355px] shadow-none hover:shadow-none">
             <Card.Content>
                 <div className="w-full aspect-square border-dashed border-2"></div>
             </Card.Content>

--- a/components/UploadLinkPolaroid.tsx
+++ b/components/UploadLinkPolaroid.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function UploadLinkPolaroid() {
     return (
-        <Card className="w-full max-w-[300px] shadow-none hover:shadow-none">
+        <Card className="w-full max-w-[275px] shadow-none hover:shadow-none">
             <Card.Content>
                 <div className="w-full aspect-square border-dashed border-2"></div>
             </Card.Content>

--- a/components/retroui/Card.tsx
+++ b/components/retroui/Card.tsx
@@ -36,7 +36,7 @@ const CardDescription = ({ className, ...props }: ICardProps) => (
 );
  
 const CardContent = ({ className, ...props }: ICardProps) => {
-  return <div className={cn("p-4", className)} {...props} />;
+  return <div className={cn("pt-4 px-4", className)} {...props} />;
 };
  
 const CardComponent = Object.assign(Card, {

--- a/lib/getSuePosts.ts
+++ b/lib/getSuePosts.ts
@@ -4,10 +4,10 @@ import { supabase } from './supabaseClient';
 export interface SuePostResponse {
     id: number;
     created_at: string;
-    photo_url: string | null;
-    location: string | null;
-    caption: string | null;
-    secret_used: string | null;
+    photo_url: string;
+    location: string;
+    caption: string;
+    secret_used: string;
 }
 
 // Retrieves all Sue posts, ordered by creation data (newest first)


### PR DESCRIPTION
## Summary
This PR introduces the foundational work for displaying Sue’s photo posts as polaroid cards in the gallery. It includes the ability for the SuePolaroid component to accept props and the initial implementation of rendering a list of polaroids in the gallery page.

## Changes
feat(sue-polaroid): add props interface and accept props in component
Refactored the SuePolaroid component to accept props for photoUrl, caption, location, and createdAt.
Added a TypeScript interface for props to ensure type safety and future extensibility.

feat(gallery): add basic polaroid map rendering
Implemented mapping over the list of posts in the gallery page to render a SuePolaroid for each post.
Ensured each polaroid receives the correct data from the post object.

## Next Steps
Style the SuePolaroid component to match the polaroid look and ensure image sizing is consistent with the upload card.
Add error handling and loading states for the gallery page.
Consider adding pagination or infinite scroll for large numbers of posts.
Write tests for the new components and rendering logic.